### PR TITLE
Try to handle eventual consistency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+version: 2
+jobs:
+  build:
+    working_directory: /go/src/github.com/Preetam/rig
+    docker:
+      - image: golang:1.11
+    steps:
+      - checkout
+      - run: go test -v -race

--- a/service_test.go
+++ b/service_test.go
@@ -49,11 +49,12 @@ func (o *testObjectStore) PutObject(name string, data io.ReadSeeker, size int64)
 	return nil
 }
 
-func Test1(t *testing.T) {
+func TestSimple(t *testing.T) {
 	rs, err := NewRiggedService(&testService{}, NewFileObjectStore("/tmp/bucket"), "my_service")
 	if err != nil {
 		t.Fatal(err)
 	}
+	rs.testSleep = true
 	t.Log(rs.Recover())
 	t.Log(rs.service)
 	rs.Apply(Operation{}, false)


### PR DESCRIPTION
Since the Rig always tries to fetch a nonexistent object on recovery, and that's one of the cases where S3 doesn't have strong consistency, we end up having a window of time where there's a high risk of inconsistency. With this change, the risk is lower (but not zero!).